### PR TITLE
Fix malformed keywords array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "ai-agents",
     "openclaw",
     "human-in-the-loop",
-    "runtime-interception",
-    "winston": "^3.11.0"
+    "runtime-interception"
   ],
   "author": "Kevin Wu <kevin@usepegasi.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
\`"winston": "^3.11.0"\` was accidentally left inside the \`keywords\` array
(a plain string array), which makes \`package.json\` invalid JSON:

\`\`\`json
"keywords": [
  ...
  "runtime-interception",
  "winston": "^3.11.0"
],
\`\`\`

This breaks \`npm install\` outright for anyone cloning the repo fresh --
including the exact setup command in CONTRIBUTING.md. \`winston\` is
already correctly listed in \`dependencies\`, so this looks like a
duplicate paste error rather than a missing dependency. Removed the
stray line; \`keywords\` is a plain string array again.

Verified: \`package.json\` parses as valid JSON, \`npm install\` succeeds
from a clean \`node_modules\`, build and full test suite (50/50) pass.